### PR TITLE
Wrapped all thrown strings in new Error to make Mocha happy.

### DIFF
--- a/lib/AUtils.js
+++ b/lib/AUtils.js
@@ -20,7 +20,7 @@ var createEmptyFileIfNotExists = function (file) {
 
 var assertFileExists = function (file) {
   if (!fs.existsSync(file)) {
-    throw "File not found: " + file;
+    throw new Error("File not found: " + file);
   }
 };
 

--- a/lib/Approvals.js
+++ b/lib/Approvals.js
@@ -11,7 +11,7 @@ var path = require('path');
 if (typeof beforeEach === "function"){
   beforeEach(function(){
     this.verify = function(){
-      throw "You must call either .mocha() or .jasmine()";
+      throw new Error("You must call either .mocha() or .jasmine()");
     };
   });
 }
@@ -76,7 +76,7 @@ process.on('exit', function() {
       }); // only pull the ones that aren't already in the 'listOfApprovedFiles'
 
     if (staleApprovals.length){
-      throw 'ERROR: Found stale approvals files: \n  - ' + staleApprovals.join('\n  - ') + '\n';
+      throw new Error('ERROR: Found stale approvals files: \n  - ' + staleApprovals.join('\n  - ') + '\n');
     }
   }
 

--- a/lib/FileApprover.js
+++ b/lib/FileApprover.js
@@ -37,7 +37,7 @@ exports.verify = function (namer, writer, reporterFactory, options) {
       reporterError = "\nError raised by reporter [" + reporter.name + "]: " + ex + "\n";
     }
 
-    throw (reporterError ? (reporterError + "\n") : "") + msg + ": \nApproved: " + approvedFileName + "\nReceived: " + receivedFileName + '\n';
+    throw new Error((reporterError ? (reporterError + "\n") : "") + msg + ": \nApproved: " + approvedFileName + "\nReceived: " + receivedFileName + '\n');
   };
 
   if (!fs.existsSync(approvedFileName)) {

--- a/lib/Providers/BeforeEachVerifierBase.js
+++ b/lib/Providers/BeforeEachVerifierBase.js
@@ -13,7 +13,7 @@ module.exports = function (Namer, usageSample, dirName) {
   // Make sure it's a valid directory
   var stats = fs.lstatSync(dirName);
   if (!stats.isDirectory()) {
-    throw "Invalid directory [" + dirName + "]. Try using the following syntax. > " + usageSample;
+    throw new Error("Invalid directory [" + dirName + "]. Try using the following syntax. > " + usageSample);
   }
 
   beforeEach(function () {

--- a/lib/Providers/Jasmine/JasmineNamer.js
+++ b/lib/Providers/Jasmine/JasmineNamer.js
@@ -32,7 +32,7 @@ var getFullTestName = function (testContext) {
 
 var JasmineNamer = function (context, path) {
   if (!context) {
-    throw "Jasmine context was not available.";
+    throw new Error("Jasmine context was not available.");
   }
   this.ctx = context;
   this.path = path;
@@ -48,7 +48,7 @@ JasmineNamer.prototype.constructor = Namer;
 JasmineNamer.prototype.pathCreator = function (type, ext) {
   if (!this.name) {
     if (!this.ctx) {
-      throw "ctx was not defined.";
+      throw new Error("ctx was not defined.");
     }
     this.name = getFullTestName(this.ctx.suite);
   }

--- a/lib/Providers/Mocha/MochaNamer.js
+++ b/lib/Providers/Mocha/MochaNamer.js
@@ -27,7 +27,7 @@ var getFullTestName = function (testContext) {
 
 var MochaNamer = function (mochaContext, path) {
   if (!mochaContext) {
-    throw "Mocha context was not ";
+    throw new Error("Mocha context was not ");
   }
   this.ctx = mochaContext;
   this.path = path;
@@ -43,7 +43,7 @@ MochaNamer.prototype.getFullTestName = getFullTestName;
 MochaNamer.prototype.pathCreator = function (type, ext) {
   if (!this.name) {
     if (!this.ctx) {
-      throw "ctx was not defined.";
+      throw new Error("ctx was not defined.");
     }
     this.name = getFullTestName(this.ctx.test);
   }

--- a/lib/Reporting/DiffReporterAggregate.js
+++ b/lib/Reporting/DiffReporterAggregate.js
@@ -29,7 +29,7 @@ DiffReporterAggregate.prototype.report = function (approved, received, execCmd) 
   if (reporter) {
     reporter.report(approved, received, execCmd);
   } else {
-    throw "No reporter found!";
+    throw new Error("No reporter found!");
   }
 };
 

--- a/lib/Reporting/ReporterFactory.js
+++ b/lib/Reporting/ReporterFactory.js
@@ -29,7 +29,7 @@ var loadReporter = function (name) {
       }
     });
 
-    throw "Error loading reporter or reporter not found [" + name + "]. Try one of the following [" + availableReporters + "]. Original Error: " + e;
+    throw new Error("Error loading reporter or reporter not found [" + name + "]. Try one of the following [" + availableReporters + "]. Original Error: " + e);
   }
   return new ReporterCtor();
 };
@@ -37,7 +37,7 @@ var loadReporter = function (name) {
 var loadAllReporters = function (reporters) {
   var reporterInstances = [];
   function throwUnknownReporterError(reporter) {
-    throw 'Unknown reporter: typeof= [' + (typeof reporter) + ']. Reporters are either a string like "gitdiff" or an object that conforms to the custom reporter interface.';
+    throw new Error('Unknown reporter: typeof= [' + (typeof reporter) + ']. Reporters are either a string like "gitdiff" or an object that conforms to the custom reporter interface.');
   }
 
   reporters.forEach(function (reporter) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -83,7 +83,7 @@ var getHomeApprovalConfig = function() {
     try {
       return yaml.safeLoad(configFileData);
     } catch (ex) {
-      throw "Error parsing " + homeConfigPath + ". " + ex;
+      throw new Error("Error parsing " + homeConfigPath + ". " + ex);
     }
   }
   return null;

--- a/test/FileApproverTests.js
+++ b/test/FileApproverTests.js
@@ -18,7 +18,7 @@ var ShouldFailCustomReporter = function () {
 
   this.report = function (/*approved, received*/) {
     console.log(arguments);
-    throw "This reporter should never run";
+    throw new Error("This reporter should never run");
   };
 
   this.name = "ShouldFailCustomReporter";

--- a/test/Reporting/ReporterFactoryTests.js
+++ b/test/Reporting/ReporterFactoryTests.js
@@ -27,7 +27,7 @@ describe('ReporterFactory', function () {
     try {
       ReporterFactory.loadReporter('wat?');
     } catch (e) {
-      if (e.indexOf("Error loading reporter or reporter not found [wat?]. Try one of the following") === -1) {
+      if (e.message.indexOf("Error loading reporter or reporter not found [wat?]. Try one of the following") === -1) {
         throw e;
       }
     }

--- a/test/commandLineTests.js
+++ b/test/commandLineTests.js
@@ -12,7 +12,7 @@ describe('Command Line', function () {
     shelljs.exec(cliTestCommand, {async:true}, function (code, output) {
       if (code !== 0) {
         console.error('code:', code, 'output:', output);
-        throw "cli script failed";
+        throw new Error("cli script failed");
       }
       done();
     });


### PR DESCRIPTION
Mocha version 2.4.5 appears to be quite unhappy about thrown strings as errors. This PR addresses the issue with thrown strings by wrapping all thrown messages in new Error().  All tests are back to a passing state, so hopefully this fix is acceptable.