### PR TITLE
fix #42

### DIFF
--- a/lib/FileApprover.js
+++ b/lib/FileApprover.js
@@ -43,21 +43,21 @@ exports.verify = function (namer, writer, reporterFactory, options) {
   if (!fs.existsSync(approvedFileName)) {
     throwReporterError("Approved file does not exist: " + approvedFileName);
   }
+  
+  function readFileAndNormalize (filename) {
+    var fileContent = fs.readFileSync(filename, 'utf8') || ""
 
-  if (!stripBOM) {
-    if (fs.statSync(approvedFileName).size !== fs.statSync(receivedFileName).size) {
-      throwReporterError("File sizes do not match");
+    // Remove a Byte Order Mark if configured
+    if (stripBOM) {
+      fileContent = fileContent.replace(/^\uFEFF/, '');
     }
+    var fileContentWithoutWindowsCR = fileContent.replace(/\r/g, "")
+    return fileContentWithoutWindowsCR
   }
 
-  var approvedFileBuffer = fs.readFileSync(approvedFileName, 'utf8') || "";
-  var receivedFileBuffer = fs.readFileSync(receivedFileName, 'utf8') || "";
+  var approvedFileBuffer = readFileAndNormalize(approvedFileName);
+  var receivedFileBuffer = readFileAndNormalize(receivedFileName);
 
-  // Remove a Byte Order Mark if configured
-  if (stripBOM) {
-    approvedFileBuffer = approvedFileBuffer.replace(/^\uFEFF/, '');
-    receivedFileBuffer = receivedFileBuffer.replace(/^\uFEFF/, '');
-  }
 
   for (var i = 0, bufferLength = approvedFileBuffer.length; i < bufferLength; i++) {
     if (approvedFileBuffer[i] !== receivedFileBuffer[i]) {


### PR DESCRIPTION
replace windows carriage returns with simple carriage returns i.e. \r\n by \n
just before char-by-char comparison

in fact when use use a merge tool and copy received to approved you get a good mix of \r\n and \r
and then the diff gives a false negative

I had to remove the size comparison consequently, not sure it is necessary