### PR TITLE
Remove unnecessary console logging

### DIFF
--- a/lib/StringWriter.js
+++ b/lib/StringWriter.js
@@ -53,10 +53,6 @@ StringWriter.prototype.write = function (filePath) {
     if (!endsWithCRLF && !endsWithLF) {
       console.log("ADDING EOL - " + JSON.stringify(this.config.EOL));
       this.outputText += this.config.EOL;
-    } else if (endsWithCRLF && this.config.EOL === LF) {
-      console.log("NOT ADDING EOL - " + JSON.stringify(this.config.EOL) + ' because ' + JSON.stringify(LF) + ' already there.');
-    } else if (endsWithLF && this.config.EOL === CRLF) {
-      console.log("NOT ADDING EOL - " + JSON.stringify(this.config.EOL) + ' because ' + JSON.stringify(CRLF) + ' already there.');
     }
 
   }


### PR DESCRIPTION
Those console.log calls are not really required and all they do is add noise to testing output.