### PR TITLE
Add support for VS Code as a Reporter

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,7 +29,7 @@ gulp.task('unitTest', function() {
       reporter: 'spec',
       slow: 500,
       timeout: 5000,
-      globals: {}
+      //globals: {}
     }));
 })
 

--- a/lib/Reporting/Reporters/vscodeReporter.js
+++ b/lib/Reporting/Reporters/vscodeReporter.js
@@ -6,13 +6,14 @@ var GenericDiffReporterBase = require('../GenericDiffReporterBase');
 var ostools = require('../../osTools');
 
 var Reporter = GenericDiffReporterBase.create(function () {
-    
+
   this.name = "vscode";
 
-  if (ostools.platform.isWindows)
+  if (ostools.platform.isWindows) {
     this.exePath = autils.searchForExecutable('code.cmd');
-  else
+  } else {
     this.exePath = autils.searchForExecutable('code');
+  }
 
 });
 

--- a/lib/Reporting/Reporters/vscodeReporter.js
+++ b/lib/Reporting/Reporters/vscodeReporter.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var child_process = require('child_process');
+var autils = require('../../AUtils');
+var GenericDiffReporterBase = require('../GenericDiffReporterBase');
+var ostools = require('../../osTools');
+
+var Reporter = GenericDiffReporterBase.create(function () {
+    
+  this.name = "vscode";
+
+  if (ostools.platform.isWindows)
+    this.exePath = autils.searchForExecutable('code.cmd');
+  else
+    this.exePath = autils.searchForExecutable('code');
+
+});
+
+Reporter.prototype.report = function (approved, received, spawn) {
+  spawn = spawn || child_process.spawn;
+  autils.createEmptyFileIfNotExists(approved);
+
+  var exe = this.exePath;
+
+  spawn(exe, ["-n", "--diff", received, approved], {
+    detached: true
+  });
+
+};
+
+module.exports = Reporter;


### PR DESCRIPTION
VS Code is a very common editor these days, and is cross-platform. Would be nice to have this reporter available, maybe even by default. This is my stab at adding it. I haven't tested it on Mac or Linux yet. Works fine for me on windows.