### PR TITLE
Fix for finding Beyond Compare 4 on Windows

### DIFF
--- a/lib/Reporting/Reporters/beyondcompareReporter.js
+++ b/lib/Reporting/Reporters/beyondcompareReporter.js
@@ -15,8 +15,8 @@ module.exports = GenericDiffReporterBase.create(function () {
     }
     app = app || autils.searchForExecutable("bcomp");
   } else if (osTool.platform.isWindows) {
-    app = autils.searchForExecutable("Beyond Compare 4", "BCompare.exe");
-    app = autils.searchForExecutable("Beyond Compare 3", "BCompare.exe");
+    app = autils.searchForExecutable("Beyond Compare 4", "BCompare.exe")
+       || autils.searchForExecutable("Beyond Compare 3", "BCompare.exe");
   }
 
   app = app || autils.searchForExecutable("bcomp");


### PR DESCRIPTION
Fixes #81