### PR TITLE
Use program lookup cache for programs whether or not they were found in PATH

### DIFF
--- a/lib/AUtils.js
+++ b/lib/AUtils.js
@@ -63,7 +63,7 @@ var trimExtension = function (filePath) {
 
 var findProgramOnPath = function (programName) {
 
-  if (_cachedProgramLookups[programName]) {
+  if (_cachedProgramLookups.hasOwnProperty(programName)) {
     return _cachedProgramLookups[programName];
   }
   var output = shell.exec(osTools.findProgramPathCommand + " " + programName, { silent: true });


### PR DESCRIPTION
My failing approval tests were taking a long time (more than a second each) and I found the time was almost all in `findProgramOnPath`. Even though an entry in `_cachedProgramLookups` existed, with a value of null representing that the program being looked up wasn't available, the way the cache was checked treated it as if it wasn't in the cache at all.

This fixes that, using the cache for anything that was _or wasn't_ found in a previous lookup.