### PR TITLE
don't call `Object.keys(unordered)` when `unordered` is `null`

### DIFF
--- a/lib/AUtils.js
+++ b/lib/AUtils.js
@@ -166,7 +166,7 @@ var recursivelyOrderKeys = function(unordered) {
     return unordered;
   }
 
-  if (typeof unordered === 'object') {
+  if (unordered !== null && typeof unordered === 'object') {
     var ordered = {};
     Object.keys(unordered).sort().forEach(function(key) {
       ordered[key] = recursivelyOrderKeys(unordered[key]);

--- a/test/AUtilsTests.js
+++ b/test/AUtilsTests.js
@@ -83,7 +83,7 @@ describe('AUtils', function () {
     },
     {
       "a": 1,
-      "b": 2
+      "b": null
     }
   ]
 }`;
@@ -100,7 +100,7 @@ describe('AUtils', function () {
             b: 2
           },
           {
-            b: 2,
+            b: null,
             a: 1
           }
         ],
@@ -124,7 +124,7 @@ describe('AUtils', function () {
             a: 1
           },
           {
-            b: 2,
+            b: null,
             a: 1
           }
         ],


### PR DESCRIPTION
`verifyAsJSON` fails when the object contains values that are set to null, as the value check inside `stringifyKeysInOrder` fails to prevent calling  `Object.keys(unordered)` when `unordered` is `null`.