### PR TITLE
Update MultiReporter example in readme to use real reporters

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -241,7 +241,7 @@ var MultiReporter = approvals.reporters.MultiReporter
 it("should use a multiple reporters", function () {
   this.verify('some data', {
     reporters: [
-      new MultiReporter(['p4merge', 'commandclipboard'])
+      new MultiReporter(['p4merge', 'copycommand'])
     ]
   });
 });


### PR DESCRIPTION
"commandclipboard" sounds like it's doing what "copycommand" does,
except it's not a real reporter. That threw me for a loop.

Now the main readme's example for using the MultiReporter works if you copy+paste it and try to run it.


