### PR TITLE
Support for custom file extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ coverage/
 
 # VS Code settings folder
 .settings/
+
+# IntelliJ
+.idea/

--- a/lib/Approvals.js
+++ b/lib/Approvals.js
@@ -126,8 +126,7 @@ var verifyAndScrub = function (dirName, testName, data, scrubber, optionsOverrid
     writer = new BinaryWriter(newOptions, data);
   } else {
     data = scrubber(data);
-
-    writer = new StringWriter(newOptions, data);
+    writer = new StringWriter(newOptions, data, newOptions.fileExtension);
   }
   verifyWithControl(namer, writer, null, newOptions);
 };

--- a/test/approvalsTests.js
+++ b/test/approvalsTests.js
@@ -38,6 +38,13 @@ describe('approvals', function () {
 
       approvals.verify(__dirname, "basic-image-test-png", imgBuffer);
     });
+
+    it("should use a overridden file name extension", function () {
+      var testName = "overridden file extension";
+      var dataToVerify = "<html><body>Hello, world!</body></html>"
+      let overrideWithFileExtension = Object.assign({ fileExtension: "html" }, approvalOverrides);
+      approvals.verify(__dirname, testName, dataToVerify, overrideWithFileExtension)
+    });
   });
 
   describe('verifyAsJSON', function () {

--- a/test/overridden file extension.approved.html
+++ b/test/overridden file extension.approved.html
@@ -1,0 +1,1 @@
+<html><body>Hello, world!</body></html>


### PR DESCRIPTION
## Description

Use `approvalOverrides` to change file extension for approved files. Fixes #112.

## The solution

Allow developers to add a `fileExtension` property to the override.