### PR TITLE
Fix bug "Cannot read property 'blockUntilReporterExits' of undefined"

### DIFF
--- a/lib/FileApprover.js
+++ b/lib/FileApprover.js
@@ -52,7 +52,7 @@ exports.verify = function (namer, writer, reporterFactory, options) {
 
     var reporterError;
     try {
-      reporter.report(approvedFileName, receivedFileName, options);
+      reporter.report(approvedFileName, receivedFileName, options || {});
     } catch (ex) {
       reporterError = "\nError raised by reporter [" + reporter.name + "]: " + ex + "\n";
     }

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "jsdoc-to-markdown": "^7.0.1",
     "mocha": "^8.3.2",
     "np": "^7.4.0",
-    "npm-check-updates": "https://github.com/raineorshine/npm-check-updates",
+    "npm-check-updates": "^11.3.0",
     "nyc": "^15.1.0",
     "pre-commit": "^1.2.2",
     "sinon": "^10.0.0"

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "jsdoc-to-markdown": "^7.0.1",
     "mocha": "^8.3.2",
     "np": "^7.4.0",
-    "npm-check-updates": "^11.3.0",
+    "npm-check-updates": "https://github.com/raineorshine/npm-check-updates",
     "nyc": "^15.1.0",
     "pre-commit": "^1.2.2",
     "sinon": "^10.0.0"


### PR DESCRIPTION
## Description

Perhaps I misunderstanding something in the readme, because I feel like most should be running into this (it's a bug on the latest release): when the `options` in lib/FileApprover.js are undefined, you get an error trying to boot up the reporter:

```bash
Error raised by reporter [Meld]: TypeError: Cannot read property 'blockUntilReporterExits' of undefined
```

I received the same error with the Visual Studio code reporter.

I do think this change should be there, because earlier in the file it checks if `options` is undefined.

## The solution

I pass an empty object if `options` is undefined. Normally I would write a failing test for this, but I am at work at the moment. I can add that later.


