### PR TITLE
GH-125 set exit code when failing postRunCleanup

### DIFF
--- a/lib/postRunCleanup.js
+++ b/lib/postRunCleanup.js
@@ -53,6 +53,7 @@ module.exports = function (config, approvedFilesMap) {
     }); // only pull the ones that aren't already in the 'normalizedApprovedFilePaths'
 
     if (staleApprovals.length) {
+      process.exitCode = 1 // make sure the process reports this failure
       throw new Error('ERROR: Found stale approvals files: \n  - ' + staleApprovals.join('\n  - ') + '\n');
     }
   }


### PR DESCRIPTION
## Description

Closes #125

## The solution

- explicitly set `process.exitCode` in the `postRunCleanup` method
- no tests impacted


