### PR TITLE
Remove unused dependency: native

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "marked-terminal": "^5.1.1",
         "minimist": "^1.2.5",
         "mkdirp": "^1.0.4",
-        "natives": "^1.1.6",
         "shelljs": "^0.8.4",
         "temp": "^0.9.4",
         "ts-jest": "^29.0.3"
@@ -12833,12 +12832,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/natives": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
-      "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==",
-      "deprecated": "This module relies on Node.js's internals and will break at some point. Do not use it, and update to graceful-fs@4.x."
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -28951,11 +28944,6 @@
           "dev": true
         }
       }
-    },
-    "natives": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
-      "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA=="
     },
     "natural-compare": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "marked-terminal": "^5.1.1",
     "minimist": "^1.2.5",
     "mkdirp": "^1.0.4",
-    "natives": "^1.1.6",
     "shelljs": "^0.8.4",
     "temp": "^0.9.4",
     "ts-jest": "^29.0.3"


### PR DESCRIPTION
## Description

On install npm is warning that the package `native` is deprecated and may break soon:

![image](https://user-images.githubusercontent.com/60802467/222874144-28a9e556-4b44-4c9d-9bd6-46d6b34222fc.png)


Closes #142. 

## The solution

Running `depcheck` indicated that the package `native` is not being used. A manual search also revealed no use of the package, so I removed it. All tests remain passing.
