### PR TITLE
Fixes Incorrect version tag in 6.2.1 #150

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "approvals",
-  "version": "v6.2.1",
+  "version": "6.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "approvals",
-      "version": "v6.2.1",
+      "version": "6.2.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "approvals",
   "description": "Approval Tests Library - Capturing Human Intelligence",
-  "version": "v6.2.1",
+  "version": "6.2.2",
   "homepage": "http://approvaltests.com",
   "author": {
     "name": "Jason Jarrett",


### PR DESCRIPTION
## Description

Fixes #150 

Removes the `v` in the version tag, so it is consistent with every other npm package on the internet.

## The solution

Just removes the `v` - next run of `npm version patch` should rev it properly, fixing this for 6.2.2+