### PR TITLE
refactor: better imports

### DIFF
--- a/lib/Reporting/GenericDiffReporterBase.ts
+++ b/lib/Reporting/GenericDiffReporterBase.ts
@@ -6,7 +6,7 @@ import { ChildProcessWithoutNullStreams } from "child_process";
 import { Reporter } from "../Core/Reporter";
 import { Config } from "../config";
 
-export default class GenericDiffReporterBase implements Reporter {
+export class GenericDiffReporterBase implements Reporter {
   name: string;
   public exePath: string = "";
   private _reporterFileLookedUp: boolean;

--- a/lib/Reporting/Reporters/beyondcompareReporter.ts
+++ b/lib/Reporting/Reporters/beyondcompareReporter.ts
@@ -1,7 +1,7 @@
 import { searchForExecutable } from "../../AUtils";
 import { platform } from "../../osTools";
-import GenericDiffReporterBase from "../GenericDiffReporterBase";
 import shelljs from "shelljs";
+import {GenericDiffReporterBase} from "../GenericDiffReporterBase";
 
 export default class BeyondCompareReporter extends GenericDiffReporterBase {
   constructor() {

--- a/lib/Reporting/Reporters/beyondcompareReporter.ts
+++ b/lib/Reporting/Reporters/beyondcompareReporter.ts
@@ -1,7 +1,7 @@
 import { searchForExecutable } from "../../AUtils";
 import { platform } from "../../osTools";
 import shelljs from "shelljs";
-import {GenericDiffReporterBase} from "../GenericDiffReporterBase";
+import { GenericDiffReporterBase } from "../GenericDiffReporterBase";
 
 export default class BeyondCompareReporter extends GenericDiffReporterBase {
   constructor() {

--- a/lib/Reporting/Reporters/codiumReporter.ts
+++ b/lib/Reporting/Reporters/codiumReporter.ts
@@ -1,6 +1,6 @@
-import GenericDiffReporterBase from "../GenericDiffReporterBase";
 import { platform } from "../../osTools";
 import { createEmptyFileIfNotExists, searchForExecutable } from "../../AUtils";
+import {GenericDiffReporterBase} from "../GenericDiffReporterBase";
 
 export default class CodiumReporter extends GenericDiffReporterBase {
   constructor() {

--- a/lib/Reporting/Reporters/codiumReporter.ts
+++ b/lib/Reporting/Reporters/codiumReporter.ts
@@ -1,6 +1,6 @@
 import { platform } from "../../osTools";
 import { createEmptyFileIfNotExists, searchForExecutable } from "../../AUtils";
-import {GenericDiffReporterBase} from "../GenericDiffReporterBase";
+import { GenericDiffReporterBase } from "../GenericDiffReporterBase";
 
 export default class CodiumReporter extends GenericDiffReporterBase {
   constructor() {

--- a/lib/Reporting/Reporters/diffmergeReporter.ts
+++ b/lib/Reporting/Reporters/diffmergeReporter.ts
@@ -1,7 +1,7 @@
 import * as shelljs from "shelljs";
 import { platform } from "../../osTools";
 import { searchForExecutable } from "../../AUtils";
-import {GenericDiffReporterBase} from "../GenericDiffReporterBase";
+import { GenericDiffReporterBase } from "../GenericDiffReporterBase";
 
 class Reporter extends GenericDiffReporterBase {
   constructor() {

--- a/lib/Reporting/Reporters/diffmergeReporter.ts
+++ b/lib/Reporting/Reporters/diffmergeReporter.ts
@@ -1,7 +1,7 @@
-import GenericDiffReporterBase from "../GenericDiffReporterBase";
 import * as shelljs from "shelljs";
 import { platform } from "../../osTools";
 import { searchForExecutable } from "../../AUtils";
+import {GenericDiffReporterBase} from "../GenericDiffReporterBase";
 
 class Reporter extends GenericDiffReporterBase {
   constructor() {

--- a/lib/Reporting/Reporters/gitdiffReporter.ts
+++ b/lib/Reporting/Reporters/gitdiffReporter.ts
@@ -1,6 +1,6 @@
-import GenericDiffReporterBase from "../GenericDiffReporterBase";
 import { createEmptyFileIfNotExists, searchForExecutable } from "../../AUtils";
 import { Config } from "../../config";
+import {GenericDiffReporterBase} from "../GenericDiffReporterBase";
 
 export default class GitDiffReporter extends GenericDiffReporterBase {
   constructor() {

--- a/lib/Reporting/Reporters/gitdiffReporter.ts
+++ b/lib/Reporting/Reporters/gitdiffReporter.ts
@@ -1,6 +1,6 @@
 import { createEmptyFileIfNotExists, searchForExecutable } from "../../AUtils";
 import { Config } from "../../config";
-import {GenericDiffReporterBase} from "../GenericDiffReporterBase";
+import { GenericDiffReporterBase } from "../GenericDiffReporterBase";
 
 export default class GitDiffReporter extends GenericDiffReporterBase {
   constructor() {

--- a/lib/Reporting/Reporters/icdiffReporter.ts
+++ b/lib/Reporting/Reporters/icdiffReporter.ts
@@ -1,5 +1,5 @@
 import { searchForExecutable } from "../../AUtils";
-import {GenericDiffReporterBase} from "../GenericDiffReporterBase";
+import { GenericDiffReporterBase } from "../GenericDiffReporterBase";
 
 export default class IcDiffReporter extends GenericDiffReporterBase {
   constructor() {

--- a/lib/Reporting/Reporters/icdiffReporter.ts
+++ b/lib/Reporting/Reporters/icdiffReporter.ts
@@ -1,5 +1,5 @@
 import { searchForExecutable } from "../../AUtils";
-import GenericDiffReporterBase from "../GenericDiffReporterBase";
+import {GenericDiffReporterBase} from "../GenericDiffReporterBase";
 
 export default class IcDiffReporter extends GenericDiffReporterBase {
   constructor() {

--- a/lib/Reporting/Reporters/kdiff3Reporter.ts
+++ b/lib/Reporting/Reporters/kdiff3Reporter.ts
@@ -1,4 +1,4 @@
-import {GenericDiffReporterBase} from "../GenericDiffReporterBase";
+import { GenericDiffReporterBase } from "../GenericDiffReporterBase";
 import { searchForExecutable } from "../../AUtils";
 
 export default class Kdiff3Reporter extends GenericDiffReporterBase {

--- a/lib/Reporting/Reporters/kdiff3Reporter.ts
+++ b/lib/Reporting/Reporters/kdiff3Reporter.ts
@@ -1,4 +1,4 @@
-import GenericDiffReporterBase from "../GenericDiffReporterBase";
+import {GenericDiffReporterBase} from "../GenericDiffReporterBase";
 import { searchForExecutable } from "../../AUtils";
 
 export default class Kdiff3Reporter extends GenericDiffReporterBase {

--- a/lib/Reporting/Reporters/kompareReporter.ts
+++ b/lib/Reporting/Reporters/kompareReporter.ts
@@ -1,5 +1,5 @@
 import { searchForExecutable } from "../../AUtils";
-import {GenericDiffReporterBase} from "../GenericDiffReporterBase";
+import { GenericDiffReporterBase } from "../GenericDiffReporterBase";
 
 export default class KompareReporter extends GenericDiffReporterBase {
   constructor() {

--- a/lib/Reporting/Reporters/kompareReporter.ts
+++ b/lib/Reporting/Reporters/kompareReporter.ts
@@ -1,5 +1,5 @@
 import { searchForExecutable } from "../../AUtils";
-import GenericDiffReporterBase from "../GenericDiffReporterBase";
+import {GenericDiffReporterBase} from "../GenericDiffReporterBase";
 
 export default class KompareReporter extends GenericDiffReporterBase {
   constructor() {

--- a/lib/Reporting/Reporters/meldReporter.ts
+++ b/lib/Reporting/Reporters/meldReporter.ts
@@ -1,4 +1,4 @@
-import GenericDiffReporterBase from "../GenericDiffReporterBase";
+import {GenericDiffReporterBase} from "../GenericDiffReporterBase";
 import { searchForExecutable } from "../../AUtils";
 
 export default class MeldReporter extends GenericDiffReporterBase {

--- a/lib/Reporting/Reporters/meldReporter.ts
+++ b/lib/Reporting/Reporters/meldReporter.ts
@@ -1,4 +1,4 @@
-import {GenericDiffReporterBase} from "../GenericDiffReporterBase";
+import { GenericDiffReporterBase } from "../GenericDiffReporterBase";
 import { searchForExecutable } from "../../AUtils";
 
 export default class MeldReporter extends GenericDiffReporterBase {

--- a/lib/Reporting/Reporters/opendiffReporter.ts
+++ b/lib/Reporting/Reporters/opendiffReporter.ts
@@ -1,5 +1,5 @@
 import { searchForExecutable } from "../../AUtils";
-import {GenericDiffReporterBase} from "../GenericDiffReporterBase";
+import { GenericDiffReporterBase } from "../GenericDiffReporterBase";
 
 export default class OpenDiffReporter extends GenericDiffReporterBase {
   constructor() {

--- a/lib/Reporting/Reporters/opendiffReporter.ts
+++ b/lib/Reporting/Reporters/opendiffReporter.ts
@@ -1,5 +1,5 @@
 import { searchForExecutable } from "../../AUtils";
-import GenericDiffReporterBase from "../GenericDiffReporterBase";
+import {GenericDiffReporterBase} from "../GenericDiffReporterBase";
 
 export default class OpenDiffReporter extends GenericDiffReporterBase {
   constructor() {

--- a/lib/Reporting/Reporters/p4mergeReporter.ts
+++ b/lib/Reporting/Reporters/p4mergeReporter.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
 import shelljs from "shelljs";
-import {GenericDiffReporterBase} from "../GenericDiffReporterBase";
+import { GenericDiffReporterBase } from "../GenericDiffReporterBase";
 import { platform } from "../../osTools";
 import { searchForExecutable } from "../../AUtils";
 

--- a/lib/Reporting/Reporters/p4mergeReporter.ts
+++ b/lib/Reporting/Reporters/p4mergeReporter.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
 import shelljs from "shelljs";
-import GenericDiffReporterBase from "../GenericDiffReporterBase";
+import {GenericDiffReporterBase} from "../GenericDiffReporterBase";
 import { platform } from "../../osTools";
 import { searchForExecutable } from "../../AUtils";
 

--- a/lib/Reporting/Reporters/tortoisemergeReporter.ts
+++ b/lib/Reporting/Reporters/tortoisemergeReporter.ts
@@ -1,5 +1,5 @@
 import { searchForExecutable } from "../../AUtils";
-import GenericDiffReporterBase from "../GenericDiffReporterBase";
+import {GenericDiffReporterBase} from "../GenericDiffReporterBase";
 
 export default class TortoiseMergeReporter extends GenericDiffReporterBase {
   constructor() {

--- a/lib/Reporting/Reporters/tortoisemergeReporter.ts
+++ b/lib/Reporting/Reporters/tortoisemergeReporter.ts
@@ -1,5 +1,5 @@
 import { searchForExecutable } from "../../AUtils";
-import {GenericDiffReporterBase} from "../GenericDiffReporterBase";
+import { GenericDiffReporterBase } from "../GenericDiffReporterBase";
 
 export default class TortoiseMergeReporter extends GenericDiffReporterBase {
   constructor() {

--- a/lib/Reporting/Reporters/vimdiffReporter.ts
+++ b/lib/Reporting/Reporters/vimdiffReporter.ts
@@ -1,4 +1,4 @@
-import {GenericDiffReporterBase} from "../GenericDiffReporterBase";
+import { GenericDiffReporterBase } from "../GenericDiffReporterBase";
 import { createEmptyFileIfNotExists, searchForExecutable } from "../../AUtils";
 
 export default class Reporter extends GenericDiffReporterBase {

--- a/lib/Reporting/Reporters/vimdiffReporter.ts
+++ b/lib/Reporting/Reporters/vimdiffReporter.ts
@@ -1,4 +1,4 @@
-import GenericDiffReporterBase from "../GenericDiffReporterBase";
+import {GenericDiffReporterBase} from "../GenericDiffReporterBase";
 import { createEmptyFileIfNotExists, searchForExecutable } from "../../AUtils";
 
 export default class Reporter extends GenericDiffReporterBase {

--- a/lib/Reporting/Reporters/visualstudioReporter.ts
+++ b/lib/Reporting/Reporters/visualstudioReporter.ts
@@ -1,4 +1,4 @@
-import GenericDiffReporterBase from "../GenericDiffReporterBase";
+import {GenericDiffReporterBase} from "../GenericDiffReporterBase";
 import { createEmptyFileIfNotExists } from "../../AUtils";
 import { platform } from "../../osTools";
 

--- a/lib/Reporting/Reporters/visualstudioReporter.ts
+++ b/lib/Reporting/Reporters/visualstudioReporter.ts
@@ -1,4 +1,4 @@
-import {GenericDiffReporterBase} from "../GenericDiffReporterBase";
+import { GenericDiffReporterBase } from "../GenericDiffReporterBase";
 import { createEmptyFileIfNotExists } from "../../AUtils";
 import { platform } from "../../osTools";
 

--- a/lib/Reporting/Reporters/vscodeReporter.ts
+++ b/lib/Reporting/Reporters/vscodeReporter.ts
@@ -1,6 +1,6 @@
-import GenericDiffReporterBase from "../GenericDiffReporterBase";
 import { platform } from "../../osTools";
 import { createEmptyFileIfNotExists, searchForExecutable } from "../../AUtils";
+import { GenericDiffReporterBase } from "../GenericDiffReporterBase";
 
 export default class VSCodeReporter extends GenericDiffReporterBase {
   constructor() {

--- a/lib/StringWriter.ts
+++ b/lib/StringWriter.ts
@@ -1,8 +1,8 @@
 import * as fs from "fs";
 import * as path from "path";
-import mkdirp from "mkdirp";
 import * as autils from "./AUtils";
 import { Config } from "./config";
+import {sync} from "mkdirp";
 
 const lineEndingRegex = new RegExp("\r?\n", "g");
 
@@ -40,7 +40,7 @@ export class StringWriter {
   write(filePath: string): void {
     const dir = path.dirname(path.normalize(filePath));
     if (!fs.existsSync(dir)) {
-      mkdirp.sync(dir);
+      sync(dir);
     }
 
     if (

--- a/lib/StringWriter.ts
+++ b/lib/StringWriter.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as autils from "./AUtils";
 import { Config } from "./config";
-import {sync} from "mkdirp";
+import { sync } from "mkdirp";
 
 const lineEndingRegex = new RegExp("\r?\n", "g");
 

--- a/lib/Utilities/Logger/SimpleLogger.ts
+++ b/lib/Utilities/Logger/SimpleLogger.ts
@@ -1,4 +1,4 @@
-import { SingleWrapper, ThreadedWrapper, Wrapper } from "./Wrapper";
+import { SingleWrapper, Wrapper } from "./Wrapper";
 
 import { LoggingInstance } from "./LoggingInstance";
 import { StringWrapper } from "./StringWrapper";

--- a/test/Reporting/GenericDiffReporterBaseTests.mts
+++ b/test/Reporting/GenericDiffReporterBaseTests.mts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import { expect } from "chai";
-import GenericDiffReporterBase from "../../lib/Reporting/GenericDiffReporterBase.js";
 import sinon from "sinon";
+import { GenericDiffReporterBase } from "../../lib/Reporting/GenericDiffReporterBase.js";
 
 describe("GenericDiffReporterBase", function () {
   let sandbox;
@@ -9,7 +9,7 @@ describe("GenericDiffReporterBase", function () {
 
   beforeEach(function () {
     sandbox = sinon.createSandbox();
-    reporter = new GenericDiffReporterBase.default("test");
+    reporter = new GenericDiffReporterBase("test");
   });
 
   afterEach(function () {


### PR DESCRIPTION
Pairing with @isidore

## Summary by Sourcery

Refactor imports by changing import statements for several dependencies and internal modules. Update usage of `mkdirp` to use the named `sync` export and switch to named exports for `GenericDiffReporterBase`.

Enhancements:
- Switch to named `sync` export from `mkdirp`.
- Use named exports for `GenericDiffReporterBase` across reporters.