### PR TITLE
stop failure if jest logging was not setup

### DIFF
--- a/lib/Logs/ApprovedFileLog.ts
+++ b/lib/Logs/ApprovedFileLog.ts
@@ -21,11 +21,16 @@ export class ApprovedFileLog {
   }
 
   public static forceClearLogFile() {
+    const logFilePath = this.ensureTempDirectoryExists();
+    fs.writeFileSync(logFilePath, "");
+  }
+
+  public static ensureTempDirectoryExists() {
     const logFilePath = this.getLogFilePath();
     if (!fs.existsSync(this.APPROVAL_TEMP_DIRECTORY)) {
       fs.mkdirSync(this.APPROVAL_TEMP_DIRECTORY);
     }
-    fs.writeFileSync(logFilePath, "");
+    return logFilePath;
   }
 
   private static getLogFilePath(): string {

--- a/lib/Providers/Jest/JestSetup.ts
+++ b/lib/Providers/Jest/JestSetup.ts
@@ -11,6 +11,7 @@ export function initializeGlobalsForJest() {
 }
 
 export function helpUserSetupJest(fileToCheck: string) {
+  ApprovedFileLog.ensureTempDirectoryExists();
   // Check if the file exists
   if (fs.existsSync(fileToCheck)) {
     // Get the date that fileToCheck was created


### PR DESCRIPTION
pairing with @isidore

## Summary by Sourcery

Bug Fixes:
- Ensure the temporary directory for Jest logs exists before attempting to write to it, preventing failures when the directory hasn't been created yet.