### PR TITLE
Added file launching and `withReporter()`

### DIFF
--- a/lib/Core/Options.ts
+++ b/lib/Core/Options.ts
@@ -78,10 +78,12 @@ export class Options {
   }
 
     withReporter(reporter: Reporter): Options {
-        const configModifier: ConfigModifier = (c) => {
+        const previousModifier = this.get("ConfigModifier", () => (t: any) => t);
+        const previousModifierWithReporter: ConfigModifier = (c) => {
+            c = previousModifier(c);
             c.reporters = [reporter];
             return c;
         };
-        return this.withConfig(configModifier);
+        return this.withConfig(previousModifierWithReporter);
     }
 }

--- a/lib/Core/Options.ts
+++ b/lib/Core/Options.ts
@@ -1,7 +1,7 @@
 import type { Scrubber } from "../Scrubbers/Scrubbers";
 import { Namer } from "../Namer";
 import { Config } from "../config";
-import {Reporter} from "./Reporter";
+import { Reporter } from "./Reporter";
 export type ConfigModifier = (t: any) => any;
 
 class FileOptions {
@@ -77,13 +77,13 @@ export class Options {
     return this.get("Namer", () => new Namer("", ""));
   }
 
-    withReporter(reporter: Reporter): Options {
-        const previousModifier = this.get("ConfigModifier", () => (t: any) => t);
-        const previousModifierWithReporter: ConfigModifier = (c) => {
-            c = previousModifier(c);
-            c.reporters = [reporter];
-            return c;
-        };
-        return this.withConfig(previousModifierWithReporter);
-    }
+  withReporter(reporter: Reporter): Options {
+    const previousModifier = this.get("ConfigModifier", () => (t: any) => t);
+    const previousModifierWithReporter: ConfigModifier = (c) => {
+      c = previousModifier(c);
+      c.reporters = [reporter];
+      return c;
+    };
+    return this.withConfig(previousModifierWithReporter);
+  }
 }

--- a/lib/Core/Options.ts
+++ b/lib/Core/Options.ts
@@ -1,6 +1,7 @@
 import type { Scrubber } from "../Scrubbers/Scrubbers";
 import { Namer } from "../Namer";
 import { Config } from "../config";
+import {Reporter} from "./Reporter";
 export type ConfigModifier = (t: any) => any;
 
 class FileOptions {
@@ -75,4 +76,12 @@ export class Options {
   getNamer(): Namer {
     return this.get("Namer", () => new Namer("", ""));
   }
+
+    withReporter(reporter: Reporter): Options {
+        const configModifier: ConfigModifier = (c) => {
+            c.reporters = [reporter];
+            return c;
+        };
+        return this.withConfig(configModifier);
+    }
 }

--- a/lib/Reporting/ReportByOpeningTheReceivedFile.ts
+++ b/lib/Reporting/ReportByOpeningTheReceivedFile.ts
@@ -1,0 +1,18 @@
+import {exec} from "child_process";
+import {Reporter} from "../Core/Reporter";
+import {Config} from "../config";
+import {platform} from "../osTools";
+
+class ReportByOpeningTheReceivedFile implements Reporter {
+    name: string = 'ReportByOpeningTheReceivedFile';
+
+    canReportOn(_fileName: string): boolean {
+        return true;
+    }
+
+    report(_approvedFileName: string, receivedFileName: string, _options?: Partial<Config>): void {
+        const openCommand = platform.isWindows ? 'start' : 'open';
+        const shell = `${openCommand} "${receivedFileName}"`;
+        exec(shell);
+    }
+}

--- a/lib/Reporting/ReportByOpeningTheReceivedFile.ts
+++ b/lib/Reporting/ReportByOpeningTheReceivedFile.ts
@@ -1,18 +1,22 @@
-import {exec} from "child_process";
-import {Reporter} from "../Core/Reporter";
-import {Config} from "../config";
-import {platform} from "../osTools";
+import { exec } from "child_process";
+import { Reporter } from "../Core/Reporter";
+import { Config } from "../config";
+import { platform } from "../osTools";
 
 class ReportByOpeningTheReceivedFile implements Reporter {
-    name: string = 'ReportByOpeningTheReceivedFile';
+  name: string = "ReportByOpeningTheReceivedFile";
 
-    canReportOn(_fileName: string): boolean {
-        return true;
-    }
+  canReportOn(_fileName: string): boolean {
+    return true;
+  }
 
-    report(_approvedFileName: string, receivedFileName: string, _options?: Partial<Config>): void {
-        const openCommand = platform.isWindows ? 'start' : 'open';
-        const shell = `${openCommand} "${receivedFileName}"`;
-        exec(shell);
-    }
+  report(
+    _approvedFileName: string,
+    receivedFileName: string,
+    _options?: Partial<Config>,
+  ): void {
+    const openCommand = platform.isWindows ? "start" : "open";
+    const shell = `${openCommand} "${receivedFileName}"`;
+    exec(shell);
+  }
 }

--- a/test/Providers/Jest/JestReporter.test.JestReporter_options.withReporter.approved.txt
+++ b/test/Providers/Jest/JestReporter.test.JestReporter_options.withReporter.approved.txt
@@ -1,0 +1,1 @@
+Goodbye

--- a/test/Providers/Jest/JestReporter.test.mts
+++ b/test/Providers/Jest/JestReporter.test.mts
@@ -25,15 +25,15 @@ describe("JestReporter", () => {
     }
   });
 
-    test("options.withReporter", () => {
-        try {
-            verify("Hello", new Options().withReporter(new JestReporter()));
-        } catch (error: any) {
-            const message = error.message;
-            // Approved file contains 'Goodbye', to force the call verify() to fail.
-            // We test that jest-formatted output has shown the differences in the exception it throws.
-            expect(message).toMatch(/- Goodbye/);
-            expect(message).toMatch(/\+ Hello/);
-        }
-    });
+  test("options.withReporter", () => {
+    try {
+      verify("Hello", new Options().withReporter(new JestReporter()));
+    } catch (error: any) {
+      const message = error.message;
+      // Approved file contains 'Goodbye', to force the call verify() to fail.
+      // We test that jest-formatted output has shown the differences in the exception it throws.
+      expect(message).toMatch(/- Goodbye/);
+      expect(message).toMatch(/\+ Hello/);
+    }
+  });
 });

--- a/test/Providers/Jest/JestReporter.test.mts
+++ b/test/Providers/Jest/JestReporter.test.mts
@@ -24,4 +24,16 @@ describe("JestReporter", () => {
       expect(message).toMatch(/\+ Hello/);
     }
   });
+
+    test("options.withReporter", () => {
+        try {
+            verify("Hello", new Options().withReporter(new JestReporter()));
+        } catch (error: any) {
+            const message = error.message;
+            // Approved file contains 'Goodbye', to force the call verify() to fail.
+            // We test that jest-formatted output has shown the differences in the exception it throws.
+            expect(message).toMatch(/- Goodbye/);
+            expect(message).toMatch(/\+ Hello/);
+        }
+    });
 });


### PR DESCRIPTION
Pairing with @isidore

## Summary by Sourcery

This pull request introduces a new reporter that opens the received file and adds the `withReporter()` option to the `Options` class, allowing users to specify a reporter to be used when verifying. It also includes a test case for the `withReporter` option.

New Features:
- Introduces a new reporter that opens the received file, allowing users to quickly view the differences.
- Adds `withReporter()` to the `Options` class, enabling users to specify a reporter to be used when verifying.

Enhancements:
- The `withReporter` option allows users to integrate custom reporting mechanisms into the verification process.

Tests:
- Adds a test case for the `withReporter` option to ensure that the reporter is correctly integrated and that the diff is displayed in the exception message.