### PR TITLE
`this` types

### DIFF
--- a/lib/Approvals.ts
+++ b/lib/Approvals.ts
@@ -33,7 +33,7 @@ import { beforeEachVerifierBase } from "./Providers/BeforeEachVerifierBase";
 export { Scrubbers as scrubbers };
 
 if (typeof beforeEach === "function") {
-  beforeEach(function (): void {
+  beforeEach(function (this: any): void {
     if (!this) {
       return;
     }

--- a/lib/Providers/BeforeEachVerifierBase.ts
+++ b/lib/Providers/BeforeEachVerifierBase.ts
@@ -62,7 +62,7 @@ export function beforeEachVerifierBase(
       `Invalid directory [${dirName}]. Try using the following syntax. > ${usageSample}`,
     );
   }
-  beforeEach(function () {
+  beforeEach(function (this: any) {
     return beforeEachLoaderFunction(Namer, dirName, this);
   });
 }

--- a/lib/Providers/Mocha/MochaApprovals.ts
+++ b/lib/Providers/Mocha/MochaApprovals.ts
@@ -22,7 +22,7 @@ import { Namer } from "../../Core/Namer";
 let mochaTest: any = null;
 
 export function it2(label: string, test: () => void): void {
-  mocha.it(label, function () {
+  mocha.it(label, function (this: any) {
     mochaTest = this;
     console.log("Mocha Test: ", mochaTest.test.name);
     test();


### PR DESCRIPTION
Pairing with @isidore

## Summary by Sourcery

Adds explicit 'this' type to beforeEach and it2 functions to ensure correct context within Mocha tests.