### PR TITLE
docs: fix formatting in readme

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -33,4 +33,4 @@
       - [x] jest.config.js: transform: {}
       - [x] NODE_OPTIONS="$NODE_OPTIONS --experimental-vm-modules" npx jest
       - [x] ReferenceError: **dirname is not defined
-                                    [[https://iamwebwiz.medium.com/how-to-fix-dirname-is-not-defined-in-es-module-scope-34d94a86694d]How to fix “**dirname is not defined in ES module scope”]]
+                                                [[https://iamwebwiz.medium.com/how-to-fix-dirname-is-not-defined-in-es-module-scope-34d94a86694d]How to fix “**dirname is not defined in ES module scope”]]

--- a/TODO.md
+++ b/TODO.md
@@ -33,4 +33,4 @@
       - [x] jest.config.js: transform: {}
       - [x] NODE_OPTIONS="$NODE_OPTIONS --experimental-vm-modules" npx jest
       - [x] ReferenceError: **dirname is not defined
-                        [[https://iamwebwiz.medium.com/how-to-fix-dirname-is-not-defined-in-es-module-scope-34d94a86694d]How to fix “**dirname is not defined in ES module scope”]]
+                                    [[https://iamwebwiz.medium.com/how-to-fix-dirname-is-not-defined-in-es-module-scope-34d94a86694d]How to fix “**dirname is not defined in ES module scope”]]

--- a/readme.md
+++ b/readme.md
@@ -148,13 +148,13 @@ By running `approvals --help`
 
 `approvals testName [options]`
 
-| Arg                       | Description                                                                                                                                                                     |
+| Arg | Description |
 | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| \*\*[-f                   | --forceapproveall]\*\*                                                                                                                                                          | Skip the approve step and apply the results to the .approved.txt file (good for a first time run) |
-| [--reporter difftool] | supports multiple EX: `--reporter opendiff --reporter gitdiff`                                                                                                                  |
-| [--outdir]            | dir to place approval file - defaults to current directory                                                                                                                      |
-| [--verbose]           | extra debug info                                                                                                                                                                |
-| TODO:                 | We need to extend the supported args to include other approval options. (file an [issue](https://github.com/approvals/Approvals.NodeJS/issues) if you need one that's not here) |
+| \*\*[-f | --forceapproveall]\*\* | Skip the approve step and apply the results to the .approved.txt file (good for a first time run) |
+| [--reporter difftool] | supports multiple EX: `--reporter opendiff --reporter gitdiff` |
+| [--outdir] | dir to place approval file - defaults to current directory |
+| [--verbose] | extra debug info |
+| TODO: | We need to extend the supported args to include other approval options. (file an [issue](https://github.com/approvals/Approvals.NodeJS/issues) if you need one that's not here) |
 
 # Examples
 


### PR DESCRIPTION
## This should be small

Done by pairing with @isidore 

Small pull requests are great and easy for me to understand and accept
Please try prefix every commits in the pull request with  [Arlo's git notation](https://github.com/RefactoringCombos/ArlosCommitNotation/blob/master/README.md)
| Prefix | Meaning |
|--------|---------|
| e   | development enviroment only - not production|
| d   | documentation only|
| t   | tests only|
| R!! | Refactoring |
| B!! | Bug Fix |
| F!! | New Feature |

## But it's not small!

Then you should setup a remote pairing session with Llewellyn ( llewellyn.falco@gmail.com )
Usually the sessions are between 45-90 minutes.

assuming you still feel it is small, please include

## Description

A description of what the PR achieves.

## The solution

Outline the implementation.
Any tests that are affected.

## Notation

I prefer lots of very small commits prefixed with [Arlo's git notation](https://github.com/RefactoringCombos/ArlosCommitNotation/blob/master/README.md)

## Summary by Sourcery

Clean up documentation formatting inconsistencies in the README and TODO markdown files.

Documentation:
- Fix the CLI arguments table formatting in the README for clearer presentation.
- Adjust a reference line’s indentation in TODO.md to align with surrounding content.